### PR TITLE
Support separate spreadsheet

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -19,3 +19,13 @@ export function applyKanaFont(name, el) {
   if (containsJapanese(name)) el.classList.add('kana');
   else el.classList.remove('kana');
 }
+
+export function getParamsSheetId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('sheetId');
+}
+
+export function getParamsTabId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('tabId');
+}

--- a/brackets-finals.html
+++ b/brackets-finals.html
@@ -1029,6 +1029,7 @@
 
     <script type="module">
       import { SHEET_ID, FINAL_BRACKETS_TAB_ID } from './assets/js/consts.js';
+      import { getParamsTabId, getParamsSheetId } from './assets/js/utils.js';
 
       // define the “steps” you want to zoom to (in the SVG’s own coordinate system)
       // adjust these x,y,width,height values by eyeballing the viewBox
@@ -1126,7 +1127,9 @@
       let bracketsData;
 
       function fetchData() {
-        const csvUrl = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${FINAL_BRACKETS_TAB_ID}`;
+        const sheetId = getParamsSheetId() || SHEET_ID;
+        const finalBracketsTabId = getParamsTabId() || FINAL_BRACKETS_TAB_ID;
+        const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&gid=${finalBracketsTabId}`;
 
         fetch(csvUrl)
           .then((res) => {

--- a/brackets.html
+++ b/brackets.html
@@ -1949,6 +1949,7 @@
 
     <script type="module">
       import { SHEET_ID, BRACKETS_TAB_ID } from './assets/js/consts.js';
+      import { getParamsTabId, getParamsSheetId } from './assets/js/utils.js';
 
       // define the “steps” you want to zoom to (in the SVG’s own coordinate system)
       // adjust these x,y,width,height values by eyeballing the viewBox
@@ -2081,7 +2082,9 @@
       let bracketsData;
 
       function fetchData() {
-        const csvUrl = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${BRACKETS_TAB_ID}`;
+        const sheetId = getParamsSheetId() || SHEET_ID;
+        const bracketsTabId = getParamsTabId() || BRACKETS_TAB_ID;
+        const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&gid=${bracketsTabId}`;
 
         fetch(csvUrl)
           .then((res) => {

--- a/interval.html
+++ b/interval.html
@@ -61,7 +61,7 @@
     <script type="module">
       import { SHEET_ID, OVERLAYS_TAB_ID } from './assets/js/consts.js';
       import { initSponsors } from './assets/js/sponsors.js';
-      import { containsJapanese } from './assets/js/utils.js';
+      import { containsJapanese, getParamsSheetId, getParamsTabId } from './assets/js/utils.js';
 
       const BRACKETS_QUALIFIERS_URL = 'brackets.html?variant=mini';
       const BRACKETS_FINALS_URL = 'brackets-finals.html?variant=mini';
@@ -409,7 +409,9 @@
       }
 
       function fetchData() {
-        const csvUrl = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${OVERLAYS_TAB_ID}`;
+        const sheetId = getParamsSheetId() || SHEET_ID;
+        const overlaysTabId = getParamsTabId() || OVERLAYS_TAB_ID;
+        const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&gid=${overlaysTabId}`;
 
         fetch(csvUrl)
           .then((res) => {

--- a/interview.html
+++ b/interview.html
@@ -52,7 +52,13 @@
     <script type="module">
       import { SHEET_ID, OVERLAYS_TAB_ID } from './assets/js/consts.js';
       import { renderNameAndScoreFromRow } from './assets/js/player-name-score.js';
-      import { applyKanaFont, containsJapanese, getActiveRow } from './assets/js/utils.js';
+      import {
+        applyKanaFont,
+        containsJapanese,
+        getActiveRow,
+        getParamsSheetId,
+        getParamsTabId,
+      } from './assets/js/utils.js';
       import { initSponsors } from './assets/js/sponsors.js';
 
       const HIDE_SCORE_AND_INTERVIEW = '--無表示--';
@@ -116,7 +122,9 @@
       }
 
       function fetchData() {
-        const csvUrl = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${OVERLAYS_TAB_ID}`;
+        const sheetId = getParamsSheetId() || SHEET_ID;
+        const overlaysTabId = getParamsTabId() || OVERLAYS_TAB_ID;
+        const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&gid=${overlaysTabId}`;
 
         fetch(csvUrl)
           .then((res) => {

--- a/tampermonkeys/out/in-game.user.js
+++ b/tampermonkeys/out/in-game.user.js
@@ -352,6 +352,16 @@ window.addEventListener('load', function () {
     if (containsJapanese(name)) el.classList.add('kana');
     else el.classList.remove('kana');
   }
+
+  function getParamsSheetId() {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('sheetId');
+  }
+
+  function getParamsTabId() {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('tabId');
+  }
   /*--- end inlined utils.js ---*/
 
   // ===== INLINED: sponsors.css =====

--- a/tampermonkeys/out/in-game.user.js
+++ b/tampermonkeys/out/in-game.user.js
@@ -1,13 +1,16 @@
 // ==UserScript==
 // @name         Rashinban Geoguessr Game Master Mode
 // @namespace    https://github.com/Zashness/rashinban2025/blob/gh-pages/tampermonkeys/out/in-game.user.js
-// @version      1.1.6
+// @version      1.1.7
 // @description  Game Master Mode mods for Rashinban2025
 // @author       Zashness
 // @match        https://www.geoguessr.com/*
 // @icon         https://rashinban.org/assets/images/favicon.ico
 // @grant        GM_addStyle
 // @grant        GM_addElement
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @grant        GM_registerMenuCommand
 // ==/UserScript==
 
 // -----------------------------------------------------------------------------
@@ -460,6 +463,25 @@ window.addEventListener('load', function () {
   }
   /*--- end inlined sponsors.js ---*/
 
+  /** START SPREADSHEET TOGGLE */
+  const DEFAULTS = { sheetId: SHEET_ID, tabId: OVERLAYS_TAB_ID };
+  const SUB_COMP = { sheetId: '1X4LSputlvX5pdP7xImtuBuCSsUhhjgQ5l5DlCNVq24s', tabId: '1383961576' };
+
+  // read stored config, or default to Rashinban
+  const sheetId = GM_getValue('sheetId', DEFAULTS.sheetId);
+  const tabId = GM_getValue('tabId', DEFAULTS.tabId);
+  const isRashinban = sheetId === DEFAULTS.sheetId && tabId === DEFAULTS.tabId;
+  const currentSheetType = isRashinban ? 'Rashinban' : 'Sub-Competition';
+  GM_registerMenuCommand(`Toggle tournament (current: ${currentSheetType})`, () => {
+    const next = isRashinban ? SUB_COMP : DEFAULTS;
+    // persist to stored config
+    GM_setValue('sheetId', next.sheetId);
+    GM_setValue('tabId', next.tabId);
+    location.reload(); // re-init with new config
+  });
+  /** END SPREADSHEET TOGGLE */
+
+  // Create sponsor container
   const sponsorContainer = document.createElement('div');
   sponsorContainer.className = 'sponsors';
   sponsorContainer.id = 'sponsors';
@@ -559,7 +581,7 @@ window.addEventListener('load', function () {
   }
 
   function fetchData() {
-    const csvUrl = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${OVERLAYS_TAB_ID}`;
+    const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&gid=${tabId}`;
 
     fetch(csvUrl)
       .then((res) => {

--- a/tampermonkeys/src/in-game.user.template.js
+++ b/tampermonkeys/src/in-game.user.template.js
@@ -1,13 +1,16 @@
 // ==UserScript==
 // @name         Rashinban Geoguessr Game Master Mode
 // @namespace    https://github.com/Zashness/rashinban2025/blob/gh-pages/tampermonkeys/out/in-game.user.js
-// @version      1.1.6
+// @version      1.1.7
 // @description  Game Master Mode mods for Rashinban2025
 // @author       Zashness
 // @match        https://www.geoguessr.com/*
 // @icon         https://rashinban.org/assets/images/favicon.ico
 // @grant        GM_addStyle
 // @grant        GM_addElement
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @grant        GM_registerMenuCommand
 // ==/UserScript==
 
 window.addEventListener('load', function () {
@@ -326,6 +329,25 @@ window.addEventListener('load', function () {
   // ===== INLINED: sponsors.js =====
   //@@SPONSORS_JS@@
 
+  /** START SPREADSHEET TOGGLE */
+  const DEFAULTS = { sheetId: SHEET_ID, tabId: OVERLAYS_TAB_ID };
+  const SUB_COMP = { sheetId: '1X4LSputlvX5pdP7xImtuBuCSsUhhjgQ5l5DlCNVq24s', tabId: '1383961576' };
+
+  // read stored config, or default to Rashinban
+  const sheetId = GM_getValue('sheetId', DEFAULTS.sheetId);
+  const tabId = GM_getValue('tabId', DEFAULTS.tabId);
+  const isRashinban = sheetId === DEFAULTS.sheetId && tabId === DEFAULTS.tabId;
+  const currentSheetType = isRashinban ? 'Rashinban' : 'Sub-Competition';
+  GM_registerMenuCommand(`Toggle tournament (current: ${currentSheetType})`, () => {
+    const next = isRashinban ? SUB_COMP : DEFAULTS;
+    // persist to stored config
+    GM_setValue('sheetId', next.sheetId);
+    GM_setValue('tabId', next.tabId);
+    location.reload(); // re-init with new config
+  });
+  /** END SPREADSHEET TOGGLE */
+
+  // Create sponsor container
   const sponsorContainer = document.createElement('div');
   sponsorContainer.className = 'sponsors';
   sponsorContainer.id = 'sponsors';
@@ -361,7 +383,7 @@ window.addEventListener('load', function () {
   }
 
   function fetchData() {
-    const csvUrl = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${OVERLAYS_TAB_ID}`;
+    const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&gid=${tabId}`;
 
     fetch(csvUrl)
       .then((res) => {


### PR DESCRIPTION
## Allow using a different spreadsheet as the "backend" data.

### Overlays 

For the overlays (interview, brackets, interval), the `sheetId` and `tabId` can be specified via URL params.
- Interval: https://zashness.github.io/rashinban2025//interval.html?sheetId=1X4LSputlvX5pdP7xImtuBuCSsUhhjgQ5l5DlCNVq24s&tabId=1383961576
- Interview: https://zashness.github.io/rashinban2025/interview.html?sheetId=1X4LSputlvX5pdP7xImtuBuCSsUhhjgQ5l5DlCNVq24s&tabId=1383961576
- Qualifiers brackets:
https://zashness.github.io/rashinban2025/brackets.html?sheetId=1X4LSputlvX5pdP7xImtuBuCSsUhhjgQ5l5DlCNVq24s&tabId=1019896571
- Finals brackets: https://zashness.github.io/rashinban2025/brackets-finals.html?sheetId=1X4LSputlvX5pdP7xImtuBuCSsUhhjgQ5l5DlCNVq24s&tabId=770647160

Falls back to the default Rashinban spreadsheet if `sheetId` & `tabId` are not specified.

### Tampermonkey

For the tampermonkey script, we rely on `GM_registerMenuCommand`.  The user can click on an option below the "Rashinban Geoguessr Game Master Mode" tampermonkey to toggle which spreadsheet to use.

<img width="431" height="446" alt="image" src="https://github.com/user-attachments/assets/412a6df5-3cde-4b69-b92e-ff10301206d5" />
